### PR TITLE
Renamed SheetsRegistryProvider to JssProvider

### DIFF
--- a/react-ssr/src/server.js
+++ b/react-ssr/src/server.js
@@ -1,15 +1,15 @@
 import React from 'react'
 import {renderToString} from 'react-dom/server'
-import {SheetsRegistryProvider, SheetsRegistry} from 'react-jss'
+import {JssProvider, SheetsRegistry} from 'react-jss'
 import Button from './Button'
 
 export default function render() {
   const sheets = new SheetsRegistry()
 
   const app = renderToString(
-    <SheetsRegistryProvider registry={sheets}>
+    <JssProvider registry={sheets}>
       <Button />
-    </SheetsRegistryProvider>
+    </JssProvider>
   )
 
   return '' +


### PR DESCRIPTION
Hey,
I Found the `react-ssr` example very useful, so I just updated it in case someone else would want to use it as a reference.

Thanks!